### PR TITLE
build: compiling for prod, without Ivy

### DIFF
--- a/components-schematics/projects/components/package.json
+++ b/components-schematics/projects/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@julianobrasil/schematics-components",
-  "version": "2.0.1-alpha.7",
+  "version": "2.0.1-alpha.8",
   "license": "MIT",
   "description": "@angular schematics for generate components",
   "keywords": [

--- a/components-schematics/tsconfig.app.json
+++ b/components-schematics/tsconfig.app.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app",
-    "types": []
+    "types": [],
   },
   "files": [
     "src/main.ts",


### PR DESCRIPTION
Angular team recommends not using Ivy for library projects yet.